### PR TITLE
Content type validation: allow plain/text for .sha1 and .md5

### DIFF
--- a/CachingProxy/src/CachingProxy.cs
+++ b/CachingProxy/src/CachingProxy.cs
@@ -226,12 +226,14 @@ namespace JetBrains.CachingProxy
           return;
         }
 
-        // If content type validation is enabled, only .html, .htm and .txt files may have text/* content type
+        // If content type validation is enabled, only .html, .htm, .txt, .sha1, .md5 files may have text/* content type
         // This prevents e.g. caching of error pages with 200 OK code (jcenter)
         var responseContentType = response.Content.Headers.ContentType?.MediaType;
         if (requestPathExtension != ".html" &&
             requestPathExtension != ".txt" &&
-            requestPathExtension != ".htm")
+            requestPathExtension != ".htm" &&
+            requestPathExtension != ".sha1" &&
+            requestPathExtension != ".md5")
         {
           if (responseContentType is MediaTypeNames.Text.Html or MediaTypeNames.Text.Plain)
           {


### PR DESCRIPTION
Prevents such warnings:
```
https://repo1.maven.org/maven2/org/eclipse/jetty/orbit/javax.el/2.1.0.v201105211819/javax.el-2.1.0.v201105211819.pom.sha1 returned content type 'text/plain' which is possibly wrong for file extension '.sha1'
```