### PR TITLE
Content type validation: allow plain/text for .sha256

### DIFF
--- a/CachingProxy/src/CachingProxy.cs
+++ b/CachingProxy/src/CachingProxy.cs
@@ -234,6 +234,7 @@ namespace JetBrains.CachingProxy
         if (requestPathExtension != ".html" &&
             requestPathExtension != ".txt" &&
             requestPathExtension != ".htm" &&
+            requestPathExtension != ".sha256" &&
             requestPathExtension != ".sha1" &&
             requestPathExtension != ".md5")
         {


### PR DESCRIPTION
Fixes:
```
{
    "EventId": 0,
    "LogLevel": "Warning",
    "Category": "JetBrains.CachingProxy.CachingProxy",
    "Message": "https://packages.jetbrains.team/maven/p/ij/intellij-dependencies/org/apache/httpcomponents/httpclient/maven-metadata.xml.sha256 returned content type 'text/plain' which is possibly wrong for file extension '.sha256'",
    "State": {
        "Message": "https://packages.jetbrains.team/maven/p/ij/intellij-dependencies/org/apache/httpcomponents/httpclient/maven-metadata.xml.sha256 returned content type 'text/plain' which is possibly wrong for file extension '.sha256'",
        "{OriginalFormat}": "https://packages.jetbrains.team/maven/p/ij/intellij-dependencies/org/apache/httpcomponents/httpclient/maven-metadata.xml.sha256 returned content type 'text/plain' which is possibly wrong for file extension '.sha256'"
    }
}
```