### PR TITLE
Support '@' symbol in URLs for npmjs.org packages

### DIFF
--- a/CachingProxy/src/CachingProxy.cs
+++ b/CachingProxy/src/CachingProxy.cs
@@ -25,7 +25,7 @@ namespace JetBrains.CachingProxy
   {
     private const int BUFFER_SIZE = 81920;
 
-    private static readonly Regex ourGoodPathChars = new Regex("^([\\x20a-zA-Z_\\-0-9./+]|%20)+$", RegexOptions.Compiled);
+    private static readonly Regex ourGoodPathChars = new Regex("^([\\x20a-zA-Z_\\-0-9./+@]|%20)+$", RegexOptions.Compiled);
     private static readonly string ourEternalCachingHeader =
       new CacheControlHeaderValue { Public = true, MaxAge = TimeSpan.FromDays(365) }.ToString();
 

--- a/CachingProxyTests/src/CachingProxyTest.cs
+++ b/CachingProxyTests/src/CachingProxyTest.cs
@@ -235,6 +235,12 @@ namespace JetBrains.CachingProxy.Tests
     }
 
     [Fact]
+    public async void Path_With_At_Symbol()
+    {
+      await AssertGetResponse("/real/@username/package/-/package-3.1.2.tgz", HttpStatusCode.OK, (message, bytes) => AssertStatusHeader(message, CachingProxyStatus.MISS));
+    }
+
+    [Fact]
     public async void Retry_After_500()
     {
       myRealTestServer.Conditional500SendErrorOnce = true;

--- a/CachingProxyTests/src/RealTestServer.cs
+++ b/CachingProxyTests/src/RealTestServer.cs
@@ -92,6 +92,7 @@ namespace JetBrains.CachingProxy.Tests
             })
             .MapGet("name with spaces.jar", (req, res, data) => res.WriteAsync("zzz.jar"))
             .MapGet("name+with+plus.jar", (req, res, data) => res.WriteAsync("zzz.jar"))
+            .MapGet("@username/package/-/package-3.1.2.tgz", (req, res, data) => res.WriteAsync("package-3.1.2.tgz"))
             .MapGet("a.jar/b.jar", (req, res, data) => res.WriteAsync("b.jar"))
             .MapGet("a.html", (req, res, data) =>
             {


### PR DESCRIPTION
The '@' symbol is used in npmjs.org package URLs (e.g., registry.npmjs.org/@username/package/-/package-3.1.2.tgz).

Tested locally with 
```
dotnet run --project CachingProxy/CachingProxy.csproj -- LocalCachePath=path/to/cache Prefixes:0=/registry.npmjs.org
wget http://127.0.0.1:5000/registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz
```