### PR TITLE
Allow percent-encoded characters in URL paths

### DIFF
--- a/CachingProxy/src/CachingProxy.cs
+++ b/CachingProxy/src/CachingProxy.cs
@@ -26,7 +26,7 @@ namespace JetBrains.CachingProxy
   {
     private const int BUFFER_SIZE = 81920;
 
-    [GeneratedRegex(@"^([\x20a-zA-Z_\-0-9./+@]|%20)+$", RegexOptions.Compiled)]
+    [GeneratedRegex(@"^([\x20a-zA-Z_\-0-9./+@]|%[0-9a-fA-F]{2})+$", RegexOptions.Compiled)]
     private static partial Regex OurGoodPathChars { get; }
     private static readonly StringValues ourEternalCachingHeader =
       new CacheControlHeaderValue { Public = true, MaxAge = TimeSpan.FromDays(365) }.ToString();

--- a/CachingProxyTests/src/CachingProxyTest.cs
+++ b/CachingProxyTests/src/CachingProxyTest.cs
@@ -238,6 +238,15 @@ namespace JetBrains.CachingProxy.Tests
     }
 
     [Fact]
+    public async Task Path_With_Percent_Encoded_Slash()
+    {
+      // npm scoped packages use %2f in registry URLs (e.g. @types%2fserve-index)
+      // Kestrel preserves %2f in Request.Path, so use extensionless path to trigger ALWAYS_REDIRECT
+      await AssertGetResponse("/real/@scope%2fpackage", HttpStatusCode.TemporaryRedirect,
+        (message, bytes) => AssertStatusHeader(message, CachingProxyStatus.ALWAYS_REDIRECT));
+    }
+
+    [Fact]
     public async Task Retry_After_500()
     {
       myRealTestServer.Conditional500SendErrorOnce = true;


### PR DESCRIPTION
The URL character allowlist regex only permitted %20 (encoded space) as a percent-encoded sequence. This caused HTTP 400 for npm scoped packages whose URLs contain %2f (encoded slash), e.g. @types%2fserve-index.

Broaden the regex to accept any valid percent-encoded sequence (%XX). Path traversal is already guarded by the separate ".." check.

See: MRI-3561